### PR TITLE
Update key deposit in lucid.ts

### DIFF
--- a/src/lucid/lucid.ts
+++ b/src/lucid/lucid.ts
@@ -76,7 +76,7 @@ export class Lucid {
           ),
         )
         .key_deposit(
-          C.BigNum.from_str(protocolParameters.keyDeposit.toString()),
+          C.BigNum.from_str('2000000'),
         )
         .pool_deposit(
           C.BigNum.from_str(protocolParameters.poolDeposit.toString()),


### PR DESCRIPTION
changed key deposit to 2M because our preprod blockfrost instance is corrupted. temp fix until resynced